### PR TITLE
Find \plotone and \plottwo graphics from AASTeX

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ A LaTeX flattening utility for academic paper submission that recursively proces
 - **Flattens LaTeX documents** by recursively processing `\input` and `\include` commands
 - **Copies graphics files** referenced by `\includegraphics` to the output directory
 - **Supports `\graphicspath`** command for flexible graphics organization
+- **Builds a unified BibTeX database** from cited entries referenced by `\bibliography{...}`
+- **Resolves bibliography databases from `TEXMFHOME`** using standard BibTeX-style lookup
 - **Preserves document structure** with clear include markers
 - **Handles circular dependencies** gracefully
 - **Configurable graphics extensions** (PDF, PNG, JPG, EPS, etc.)
@@ -114,6 +116,7 @@ flatexpy main.tex -o submission/
 # Result
 submission/
 ├── main_flattened.tex  # Single file with all content
+├── main_flattened.bib  # Unified bibliography with cited entries
 ├── diagram1.pdf        # Copied graphics
 └── plot1.png
 ```
@@ -151,6 +154,16 @@ flatexpy automatically processes `\graphicspath` commands:
 \graphicspath{{figures/}{images/}}
 \includegraphics{plot1}  % Finds figures/plot1.png or images/plot1.png
 ```
+
+### BibTeX Handling
+
+flatexpy scans `\cite...{}` and `\bibliography{...}` commands while flattening. It then writes a merged `.bib` file next to the flattened document and rewrites the LaTeX to reference that unified bibliography.
+
+```latex
+\bibliography{local,lsst,lsst-dm,refs_ads,refs,books,ivoa}
+```
+
+The resolver checks local `.bib` files first, then searches `TEXMFHOME` for matching database names.
 
 ### Include Markers
 
@@ -212,7 +225,6 @@ tox -e lint
 
 - [ ] Feature for removing commented lines
 - [ ] Support for standalone and import packages
-- [ ] Support for bibtex
 
 ## Contributing
 

--- a/flatexpy/flatexpy_core.py
+++ b/flatexpy/flatexpy_core.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple
 
-from pybtex.database import BibliographyData, parse_file
+from pybtex.database import BibliographyData, Entry, parse_file
 
 
 def _setup_logger() -> logging.Logger:
@@ -87,8 +87,12 @@ class LatexExpander:
         # From AAS macros:
         # \plotone{image.pdf}
         # \plottwo{image1.jpg}{image2.pdf}
+        # \plotone and \includegraphics take a single mandatory argument;
+        # only \plottwo takes a second one (LaTeX permits whitespace between
+        # the two arguments).
         self._includegraphics_pattern = re.compile(
-            r"\\(?:includegraphics|plotone|plottwo)(?:\[[^\]]*\])?\{([^}]+)\}(?:\{([^}]+)\})?"
+            r"\\(?:includegraphics|plotone)(?:\[[^\]]*\])?\{([^}]+)\}"
+            r"|\\plottwo(?:\[[^\]]*\])?\{([^}]+)\}\s*\{([^}]+)\}"
         )
         self._bibliography_pattern = re.compile(r"\\bibliography\{([^}]+)\}")
         self._citation_pattern = re.compile(
@@ -104,7 +108,7 @@ class LatexExpander:
         self._seen_citation_keys: Set[str] = set()
         self._missing_citation_keys: Set[str] = set()
         self._bib_output_stem: Optional[str] = None
-        self._bib_entries_by_key: Dict[str, object] = {}
+        self._bib_entries_by_key: Dict[str, Entry] = {}
         self._bib_entry_order: List[str] = []
 
     def _extract_bibliography_files(self, line: str) -> List[str]:
@@ -197,7 +201,7 @@ class LatexExpander:
             self._bib_entry_order.append(key)
 
     def _add_bib_entry_with_crossref(
-        self, key: str, selected_entries: "Dict[str, object]"
+        self, key: str, selected_entries: "Dict[str, Entry]"
     ) -> None:
         """Add a bibliography entry and any needed crossref target."""
         if key in selected_entries:
@@ -232,7 +236,7 @@ class LatexExpander:
             database = parse_file(str(bib_path))
             self._collect_bib_entries(database, str(bib_path))
 
-        selected_entries: "Dict[str, object]" = dict()
+        selected_entries: Dict[str, Entry] = {}
         for citation_key in self._citation_keys:
             self._add_bib_entry_with_crossref(citation_key, selected_entries)
 
@@ -389,8 +393,9 @@ class LatexExpander:
             return line
         for graphic_name in match.groups():
             if not graphic_name:
-                # This happens when plottwo is not used and there is only
-                # one match.
+                # Capture groups for the regex branch that did not match are
+                # None: the single-argument group for \plottwo, or the two
+                # \plottwo groups for \includegraphics and \plotone.
                 continue
             graphics_path = self._find_graphics_file(graphic_name, root_dir)
             if graphics_path:
@@ -398,9 +403,7 @@ class LatexExpander:
                 self._copy_graphics_file(graphics_path, output_dir)
                 line = line.replace(graphic_name, filename)
             else:
-                logger.warning(
-                    "Graphics file not found: \\includegraphics{%s}", graphic_name
-                )
+                logger.warning("Graphics file not found: %s", graphic_name)
         return line
 
     def _process_input_include(

--- a/flatexpy/flatexpy_core.py
+++ b/flatexpy/flatexpy_core.py
@@ -133,12 +133,13 @@ class LatexExpander:
             )
         return citation_keys
 
-    def _update_bibliography_state(self, line: str) -> None:
+    def _update_bibliography_state(self, line: str) -> bool:
         """Track bibliography databases and cited keys from a line."""
         if not self.config.enable_bibtex:
-            return
+            return False
 
-        for bib_name in self._extract_bibliography_files(line):
+        bibliography_files = self._extract_bibliography_files(line)
+        for bib_name in bibliography_files:
             if bib_name not in self._bibliography_files:
                 self._bibliography_files.append(bib_name)
 
@@ -146,6 +147,8 @@ class LatexExpander:
             if citation_key not in self._seen_citation_keys:
                 self._seen_citation_keys.add(citation_key)
                 self._citation_keys.append(citation_key)
+
+        return bool(bibliography_files)
 
     def _rewrite_bibliography_command(self, line: str) -> str:
         """Rewrite bibliography commands to point at the unified output .bib."""
@@ -505,13 +508,14 @@ class LatexExpander:
                 flattened_content.append(line)
                 continue
 
-            self._update_bibliography_state(line)
+            has_bibliography = self._update_bibliography_state(line)
             # Process graphics paths
             self._update_graphics_path(line)
 
             # Process includegraphics and update line
             line = self._process_includegraphics(line, root_dir, output_dir)
-            line = self._rewrite_bibliography_command(line)
+            if has_bibliography:
+                line = self._rewrite_bibliography_command(line)
 
             # Process input/include
             processed_line, _ = self._process_input_include(line, root_dir, output_dir)

--- a/flatexpy/flatexpy_core.py
+++ b/flatexpy/flatexpy_core.py
@@ -109,6 +109,9 @@ class LatexExpander:
 
     def _extract_bibliography_files(self, line: str) -> List[str]:
         """Extract bibliography database names from a line."""
+        if "\\bibliography{" not in line:
+            return []
+
         matches = self._bibliography_pattern.findall(line)
         bibliography_files: List[str] = []
         for match in matches:
@@ -119,6 +122,9 @@ class LatexExpander:
 
     def _extract_citation_keys(self, line: str) -> List[str]:
         """Extract citation keys from cite-like commands in a line."""
+        if "\\cite" not in line and "\\nocite{" not in line:
+            return []
+
         matches = self._citation_pattern.findall(line)
         citation_keys: List[str] = []
         for match in matches:

--- a/flatexpy/flatexpy_core.py
+++ b/flatexpy/flatexpy_core.py
@@ -13,7 +13,9 @@ import shutil
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List, Optional, Set, Tuple
+from typing import Dict, List, Optional, Set, Tuple
+
+from pybtex.database import BibliographyData, parse_file
 
 
 def _setup_logger() -> logging.Logger:
@@ -45,6 +47,9 @@ class LatexExpandConfig:
     ignore_commented_lines: bool = True
     root_directory: str = "."
     output_encoding: str = "utf-8"
+    enable_bibtex: bool = True
+    texmfhome: Optional[str] = None
+    bib_output_name: Optional[str] = None
 
 
 class LatexExpandError(Exception):
@@ -85,11 +90,148 @@ class LatexExpander:
         self._includegraphics_pattern = re.compile(
             r"\\(?:includegraphics|plotone|plottwo)(?:\[[^\]]*\])?\{([^}]+)\}(?:\{([^}]+)\})?"
         )
+        self._bibliography_pattern = re.compile(r"\\bibliography\{([^}]+)\}")
+        self._citation_pattern = re.compile(
+            r"\\(?:cite[a-zA-Z*]*|nocite)\s*(?:\[[^\]]*\]\s*)*\{([^}]+)\}"
+        )
 
         # State tracking
         self._visited_files: Set[str] = set()
         self._graphics_paths: List[str] = []
         self._collected_graphics: Set[str] = set()
+        self._bibliography_files: List[str] = []
+        self._citation_keys: List[str] = []
+        self._seen_citation_keys: Set[str] = set()
+        self._missing_citation_keys: Set[str] = set()
+        self._bib_output_stem: Optional[str] = None
+        self._bib_entries_by_key: Dict[str, object] = {}
+        self._bib_entry_order: List[str] = []
+
+    def _extract_bibliography_files(self, line: str) -> List[str]:
+        """Extract bibliography database names from a line."""
+        matches = self._bibliography_pattern.findall(line)
+        bibliography_files: List[str] = []
+        for match in matches:
+            bibliography_files.extend(
+                [name.strip() for name in match.split(",") if name.strip()]
+            )
+        return bibliography_files
+
+    def _extract_citation_keys(self, line: str) -> List[str]:
+        """Extract citation keys from cite-like commands in a line."""
+        matches = self._citation_pattern.findall(line)
+        citation_keys: List[str] = []
+        for match in matches:
+            citation_keys.extend(
+                [key.strip() for key in match.split(",") if key.strip()]
+            )
+        return citation_keys
+
+    def _update_bibliography_state(self, line: str) -> None:
+        """Track bibliography databases and cited keys from a line."""
+        if not self.config.enable_bibtex:
+            return
+
+        for bib_name in self._extract_bibliography_files(line):
+            if bib_name not in self._bibliography_files:
+                self._bibliography_files.append(bib_name)
+
+        for citation_key in self._extract_citation_keys(line):
+            if citation_key not in self._seen_citation_keys:
+                self._seen_citation_keys.add(citation_key)
+                self._citation_keys.append(citation_key)
+
+    def _rewrite_bibliography_command(self, line: str) -> str:
+        """Rewrite bibliography commands to point at the unified output .bib."""
+        if (
+            not self.config.enable_bibtex
+            or self._bib_output_stem is None
+            or not self._extract_bibliography_files(line)
+        ):
+            return line
+        return self._bibliography_pattern.sub(
+            rf"\\bibliography{{{self._bib_output_stem}}}", line
+        )
+
+    def _resolve_bib_path(self, bib_name: str, root_dir: str) -> Path:
+        """Resolve a BibTeX database path using BibTeX-like lookup order."""
+        candidate = Path(root_dir) / f"{bib_name}.bib"
+        if candidate.exists():
+            return candidate
+
+        texmfhome = self.config.texmfhome or os.environ.get("TEXMFHOME")
+        if texmfhome:
+            texmfhome_path = Path(texmfhome)
+            bibtex_root = texmfhome_path / "bibtex" / "bib"
+            search_roots = [bibtex_root] if bibtex_root.exists() else [texmfhome_path]
+            matches: List[Path] = []
+            for search_root in search_roots:
+                matches.extend(sorted(search_root.glob(f"**/{bib_name}.bib")))
+            if matches:
+                return matches[0]
+
+        raise LatexExpandError(f"Bibliography database not found: {bib_name}.bib")
+
+    def _collect_bib_entries(
+        self, database: BibliographyData, source_name: str
+    ) -> None:
+        """Collect entries from a database while preserving first-match order."""
+        for key, entry in database.entries.items():
+            if key in self._bib_entries_by_key:
+                logger.warning(
+                    "Duplicate bibliography entry '%s' ignored from %s",
+                    key,
+                    source_name,
+                )
+                continue
+            self._bib_entries_by_key[key] = entry
+            self._bib_entry_order.append(key)
+
+    def _add_bib_entry_with_crossref(
+        self, key: str, selected_entries: "Dict[str, object]"
+    ) -> None:
+        """Add a bibliography entry and any needed crossref target."""
+        if key in selected_entries:
+            return
+
+        entry = self._bib_entries_by_key.get(key)
+        if entry is None:
+            self._missing_citation_keys.add(key)
+            logger.warning("Citation key not found in bibliography databases: %s", key)
+            return
+
+        crossref_key = entry.fields.get("crossref")
+        if crossref_key:
+            self._add_bib_entry_with_crossref(crossref_key, selected_entries)
+
+        selected_entries[key] = entry
+
+    def _write_bibliography_file(self, output_dir: str) -> None:
+        """Write the merged bibliography file beside the flattened LaTeX."""
+        if not self.config.enable_bibtex or not self._bibliography_files:
+            return
+
+        if self._bib_output_stem is None:
+            raise LatexExpandError("BibTeX output filename was not initialized")
+
+        self._bib_entries_by_key.clear()
+        self._bib_entry_order.clear()
+        self._missing_citation_keys.clear()
+
+        for bib_name in self._bibliography_files:
+            bib_path = self._resolve_bib_path(bib_name, self.config.root_directory)
+            database = parse_file(str(bib_path))
+            self._collect_bib_entries(database, str(bib_path))
+
+        selected_entries: "Dict[str, object]" = dict()
+        for citation_key in self._citation_keys:
+            self._add_bib_entry_with_crossref(citation_key, selected_entries)
+
+        output_path = Path(output_dir) / f"{self._bib_output_stem}.bib"
+        BibliographyData(entries=selected_entries).to_file(
+            str(output_path), bib_format="bibtex"
+        )
+        logger.info("Unified bibliography written to: %s", output_path)
 
     def _resolve_file_path(self, file_path: str) -> Path:
         """Resolve file path and check existence.
@@ -336,11 +478,13 @@ class LatexExpander:
                 flattened_content.append(line)
                 continue
 
+            self._update_bibliography_state(line)
             # Process graphics paths
             self._update_graphics_path(line)
 
             # Process includegraphics and update line
             line = self._process_includegraphics(line, root_dir, output_dir)
+            line = self._rewrite_bibliography_command(line)
 
             # Process input/include
             processed_line, _ = self._process_input_include(line, root_dir, output_dir)
@@ -365,16 +509,27 @@ class LatexExpander:
             input_path = self._resolve_file_path(input_file)
             root_dir = self.config.root_directory
             output_dir: str = os.path.split(output_file)[0]
+            bib_output_name = (
+                self.config.bib_output_name or f"{input_path.stem}_flattened"
+            )
 
             # Reset state for new operation
             self._visited_files.clear()
             self._graphics_paths.clear()
             self._collected_graphics.clear()
+            self._bibliography_files.clear()
+            self._citation_keys.clear()
+            self._seen_citation_keys.clear()
+            self._missing_citation_keys.clear()
+            self._bib_entries_by_key.clear()
+            self._bib_entry_order.clear()
+            self._bib_output_stem = Path(bib_output_name).stem
 
             logger.info("Starting LaTeX flattening: %s to %s", input_file, output_file)
             flattened_content = self._flatten_file(
                 str(input_path), root_dir, output_dir
             )
+            self._write_bibliography_file(output_dir)
 
             if output_file:
                 with open(output_file, "w", encoding=self.config.output_encoding) as f:
@@ -392,6 +547,9 @@ class LatexExpander:
         logger.info("ignore_commented_lines :: %s", self.config.ignore_commented_lines)
         logger.info("root_directory         :: %s", self.config.root_directory)
         logger.info("output_encoding        :: %s", self.config.output_encoding)
+        logger.info("enable_bibtex          :: %s", self.config.enable_bibtex)
+        logger.info("texmfhome              :: %s", self.config.texmfhome)
+        logger.info("bib_output_name        :: %s", self.config.bib_output_name)
 
 
 def main() -> None:

--- a/flatexpy/flatexpy_core.py
+++ b/flatexpy/flatexpy_core.py
@@ -78,8 +78,12 @@ class LatexExpander:
         # Compiled regex patterns for better performance
         self._input_pattern = re.compile(r"\\(input|include)\{([^}]+)\}")
         self._graphicspath_pattern = re.compile(r"\\graphicspath\{((\{[^}]+\})+)\}")
+        # \includegraphics[...]{image.pdf}
+        # From AAS macros:
+        # \plotone{image.pdf}
+        # \plottwo{image1.jpg}{image2.pdf}
         self._includegraphics_pattern = re.compile(
-            r"\\includegraphics(?:\[[^\]]*\])?\{([^}]+)\}"
+            r"\\(?:includegraphics|plotone|plottwo)(?:\[[^\]]*\])?\{([^}]+)\}(?:\{([^}]+)\})?"
         )
 
         # State tracking
@@ -211,14 +215,20 @@ class LatexExpander:
         match = self._includegraphics_pattern.search(line)
         if not match:
             return line
-        graphic_name: str = match.group(1)
-        graphics_path = self._find_graphics_file(graphic_name, root_dir)
-        if graphics_path:
-            filename: str = os.path.basename(graphics_path)
-            self._copy_graphics_file(graphics_path, output_dir)
-            line = line.replace(graphic_name, filename)
-            return line
-        logger.warning("Graphics file not found: \\includegraphics{%s}", graphic_name)
+        for graphic_name in match.groups():
+            if not graphic_name:
+                # This happens when plottwo is not used and there is only
+                # one match.
+                continue
+            graphics_path = self._find_graphics_file(graphic_name, root_dir)
+            if graphics_path:
+                filename: str = os.path.basename(graphics_path)
+                self._copy_graphics_file(graphics_path, output_dir)
+                line = line.replace(graphic_name, filename)
+            else:
+                logger.warning(
+                    "Graphics file not found: \\includegraphics{%s}", graphic_name
+                )
         return line
 
     def _process_input_include(

--- a/flatexpy/flatexpy_core.py
+++ b/flatexpy/flatexpy_core.py
@@ -227,6 +227,8 @@ class LatexExpander:
         for citation_key in self._citation_keys:
             self._add_bib_entry_with_crossref(citation_key, selected_entries)
 
+        selected_entries = dict(sorted(selected_entries.items()))
+
         output_path = Path(output_dir) / f"{self._bib_output_stem}.bib"
         output = BibliographyData(entries=selected_entries).to_string("bibtex")
         normalized_output = self._normalize_bibliography_output(output)

--- a/flatexpy/flatexpy_core.py
+++ b/flatexpy/flatexpy_core.py
@@ -228,10 +228,29 @@ class LatexExpander:
             self._add_bib_entry_with_crossref(citation_key, selected_entries)
 
         output_path = Path(output_dir) / f"{self._bib_output_stem}.bib"
-        BibliographyData(entries=selected_entries).to_file(
-            str(output_path), bib_format="bibtex"
-        )
+        output = BibliographyData(entries=selected_entries).to_string("bibtex")
+        normalized_output = self._normalize_bibliography_output(output)
+        output_path.write_text(normalized_output, encoding=self.config.output_encoding)
         logger.info("Unified bibliography written to: %s", output_path)
+
+    def _normalize_bibliography_output(self, output: str) -> str:
+        """Fix known pybtex escaping issues in serialized BibTeX output."""
+        # pybtex currently escapes existing escapes, so collapse doubled
+        # backslashes after serialization.
+        # See
+        # https://codeberg.org/pybtex/pybtex/issues/28#issuecomment-12578364
+        output = output.replace("\\\\", "\\")
+
+        # URL-like fields should not keep pybtex's additional escaping.
+        lines = output.splitlines()
+        for index, line in enumerate(lines):
+            if re.match(r"^\s*(adsurl|url|doi) =", line):
+                lines[index] = line.replace("\\", "")
+
+        normalized_output = "\n".join(lines)
+        if output.endswith("\n"):
+            normalized_output += "\n"
+        return normalized_output
 
     def _resolve_file_path(self, file_path: str) -> Path:
         """Resolve file path and check existence.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,9 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "flatexpy"
 version = "0.0.1"
-dependencies = []
+dependencies = [
+  "pybtex >= 0.24",
+]
 requires-python = ">=3.9"
 authors = [
   {name = "Tomohito Amano", email = "amanotomohito040@gmail.com"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,9 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "flatexpy"
 version = "0.0.2"
-dependencies = []
+dependencies = [
+  "pybtex >= 0.24",
+]
 requires-python = ">=3.9"
 authors = [
   {name = "Tomohito Amano", email = "amanotomohito040@gmail.com"}

--- a/tests/integration/test_complex_documents.py
+++ b/tests/integration/test_complex_documents.py
@@ -179,6 +179,64 @@ class TestComplexDocuments:
             finally:
                 os.chdir(original_cwd)
 
+    def test_document_with_texmfhome_bibliography(self) -> None:
+        """Test bibliography merging from local files and TEXMFHOME."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            original_cwd = os.getcwd()
+            os.chdir(temp_dir)
+
+            try:
+                texmfhome = os.path.join(temp_dir, "texmf")
+                os.makedirs("sections")
+                os.makedirs("output")
+                os.makedirs(os.path.join(texmfhome, "bibtex", "bib", "lsst"), exist_ok=True)
+
+                with open("main.tex", "w", encoding="utf-8") as f:
+                    f.write(
+                        "\\documentclass{article}\n"
+                        "\\begin{document}\n"
+                        "\\cite{localkey}\n"
+                        "\\input{sections/body}\n"
+                        "\\bibliography{local,lsst}\n"
+                        "\\end{document}\n"
+                    )
+
+                with open("sections/body.tex", "w", encoding="utf-8") as f:
+                    f.write("External citation \\citep{texmfkey}.\n")
+
+                with open("local.bib", "w", encoding="utf-8") as f:
+                    f.write(
+                        "@article{localkey,\n"
+                        "  title = {Local Reference}\n"
+                        "}\n"
+                    )
+
+                with open(
+                    os.path.join(texmfhome, "bibtex", "bib", "lsst", "lsst.bib"),
+                    "w",
+                    encoding="utf-8",
+                ) as f:
+                    f.write(
+                        "@article{texmfkey,\n"
+                        "  title = {TEXMFHOME Reference}\n"
+                        "}\n"
+                    )
+
+                config = LatexExpandConfig(root_directory=".", texmfhome=texmfhome)
+                expander = LatexExpander(config)
+                result = expander.flatten_latex("main.tex", "output/main_flat.tex")
+
+                assert "\\bibliography{main_flattened}" in result
+                assert os.path.exists("output/main_flattened.bib")
+
+                with open("output/main_flattened.bib", "r", encoding="utf-8") as f:
+                    merged_bib = f.read()
+                    assert "localkey" in merged_bib
+                    assert "texmfkey" in merged_bib
+
+            finally:
+                os.chdir(original_cwd)
+
     def test_academic_paper_structure(self) -> None:
         """Test realistic academic paper structure."""
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -323,6 +381,13 @@ class TestComplexDocuments:
                 for fig in figures:
                     with open(f"figures/{fig}", "wb") as f:
                         f.write(f"fake {fig} data".encode())
+
+                with open("references.bib", "w", encoding="utf-8") as f:
+                    f.write(
+                        "@article{paperref,\n"
+                        "  title = {Paper Reference}\n"
+                        "}\n"
+                    )
 
                 os.makedirs("output")
 
@@ -497,6 +562,13 @@ class TestComplexDocuments:
                 # Create figure
                 with open("figures/architecture.pdf", "wb") as f:
                     f.write(b"architecture diagram data")
+
+                with open("thesis_refs.bib", "w", encoding="utf-8") as f:
+                    f.write(
+                        "@article{thesisref,\n"
+                        "  title = {Thesis Reference}\n"
+                        "}\n"
+                    )
 
                 os.makedirs("output")
 

--- a/tests/unit/test_expander_core.py
+++ b/tests/unit/test_expander_core.py
@@ -502,3 +502,20 @@ class TestLatexExpanderCore:
                 assert "alpha" in merged_content
                 assert "beta" in merged_content
                 assert "gamma" not in merged_content
+
+    def test_normalize_bibliography_output_fixes_pybtex_escaping(self) -> None:
+        """Test post-processing for known pybtex escaping issues."""
+        output = (
+            "@article{ref,\n"
+            "  title = {A\\\\_B and C\\\\#D},\n"
+            "  url = {https://example.com/a\\\\_b\\\\#c},\n"
+            "  doi = {10.1234/foo\\\\_bar},\n"
+            "  adsurl = {https://ads.example/x\\\\_y}\n"
+            "}\n"
+        )
+
+        normalized = self.expander._normalize_bibliography_output(output)
+        assert "title = {A\\_B and C\\#D}" in normalized
+        assert "url = {https://example.com/a_b#c}" in normalized
+        assert "doi = {10.1234/foo_bar}" in normalized
+        assert "adsurl = {https://ads.example/x_y}" in normalized

--- a/tests/unit/test_expander_core.py
+++ b/tests/unit/test_expander_core.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
+from pybtex.database import parse_file
 
 from flatexpy.flatexpy_core import (
     GraphicsNotFoundError,
@@ -42,6 +43,8 @@ class TestLatexExpanderCore:
         assert len(self.expander._visited_files) == 0
         assert len(self.expander._graphics_paths) == 0
         assert len(self.expander._collected_graphics) == 0
+        assert len(self.expander._bibliography_files) == 0
+        assert len(self.expander._citation_keys) == 0
 
     def test_compiled_patterns(self) -> None:
         """Test that regex patterns are compiled correctly."""
@@ -57,7 +60,12 @@ class TestLatexExpanderCore:
         # Test includegraphics pattern
         assert (
             self.expander._includegraphics_pattern.pattern
-            == r"\\includegraphics(?:\[[^\]]*\])?\{([^}]+)\}"
+            == r"\\(?:includegraphics|plotone|plottwo)(?:\[[^\]]*\])?\{([^}]+)\}(?:\{([^}]+)\})?"
+        )
+        assert self.expander._bibliography_pattern.pattern == r"\\bibliography\{([^}]+)\}"
+        assert (
+            self.expander._citation_pattern.pattern
+            == r"\\(?:cite[a-zA-Z*]*|nocite)\s*(?:\[[^\]]*\]\s*)*\{([^}]+)\}"
         )
 
     def test_is_line_commented(self) -> None:
@@ -130,6 +138,68 @@ class TestLatexExpanderCore:
         line3 = "\\graphicspath{{figures/}}"
         self.expander._update_graphics_path(line3)
         assert self.expander._graphics_paths == ["figures", "images"]
+
+    def test_extract_bibliography_files(self) -> None:
+        """Test extracting bibliography database names."""
+        line = "\\bibliography{local,lsst, refs_ads}"
+        assert self.expander._extract_bibliography_files(line) == [
+            "local",
+            "lsst",
+            "refs_ads",
+        ]
+
+    def test_extract_citation_keys(self) -> None:
+        """Test extracting citation keys from cite-like commands."""
+        line = "Text \\citep[see][]{key1,key2} and \\nocite{key3}"
+        assert self.expander._extract_citation_keys(line) == ["key1", "key2", "key3"]
+
+    def test_rewrite_bibliography_command(self) -> None:
+        """Test rewriting bibliography command to merged output."""
+        self.expander._bib_output_stem = "main_flattened"
+        line = "\\bibliography{local,lsst}\n"
+        assert (
+            self.expander._rewrite_bibliography_command(line)
+            == "\\bibliography{main_flattened}\n"
+        )
+
+    def test_resolve_bib_path_prefers_local_file(self) -> None:
+        """Test local bibliography databases are preferred over TEXMFHOME."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root_dir = Path(temp_dir)
+            texmf_dir = root_dir / "texmf"
+            local_bib = root_dir / "refs.bib"
+            texmf_bib = texmf_dir / "bibtex" / "bib" / "misc" / "refs.bib"
+            texmf_bib.parent.mkdir(parents=True)
+            local_bib.write_text("@article{localref, title={Local}}\n", encoding="utf-8")
+            texmf_bib.write_text("@article{texmfref, title={Texmf}}\n", encoding="utf-8")
+
+            expander = LatexExpander(
+                LatexExpandConfig(root_directory=temp_dir, texmfhome=str(texmf_dir))
+            )
+            assert expander._resolve_bib_path("refs", temp_dir) == local_bib
+
+    def test_collect_bib_entries_keeps_first_duplicate(self) -> None:
+        """Test duplicate keys keep the first database entry."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            first_bib = Path(temp_dir) / "first_refs.bib"
+            second_bib = Path(temp_dir) / "second_refs.bib"
+            first_bib.write_text(
+                "@article{dupkey, title={First Title}}\n", encoding="utf-8"
+            )
+            second_bib.write_text(
+                "@article{dupkey, title={Second Title}}\n", encoding="utf-8"
+            )
+
+            first_db = parse_file(str(first_bib))
+            second_db = parse_file(str(second_bib))
+
+            self.expander._collect_bib_entries(first_db, str(first_bib))
+            self.expander._collect_bib_entries(second_db, str(second_bib))
+
+            assert (
+                self.expander._bib_entries_by_key["dupkey"].fields["title"]
+                == "First Title"
+            )
 
     def test_show_config(self) -> None:
         """Test configuration display."""
@@ -383,3 +453,52 @@ class TestLatexExpanderCore:
             with open(output_file, "r") as f:
                 content = f.read()
                 assert content == result
+
+    def test_flatten_latex_writes_merged_bibliography(self) -> None:
+        """Test bibliography collection and unified .bib generation."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            input_file = os.path.join(temp_dir, "main.tex")
+            included_file = os.path.join(temp_dir, "section.tex")
+            bibliography_file = os.path.join(temp_dir, "refs.bib")
+            output_dir = os.path.join(temp_dir, "output")
+            output_file = os.path.join(output_dir, "main_flat.tex")
+            os.makedirs(output_dir)
+
+            with open(input_file, "w", encoding="utf-8") as f:
+                f.write(
+                    "\\documentclass{article}\n"
+                    "\\begin{document}\n"
+                    "\\citep{alpha}\n"
+                    "\\input{section}\n"
+                    "\\bibliography{refs}\n"
+                    "\\end{document}\n"
+                )
+
+            with open(included_file, "w", encoding="utf-8") as f:
+                f.write("Nested cite \\cite{beta}.\n")
+
+            with open(bibliography_file, "w", encoding="utf-8") as f:
+                f.write(
+                    "@article{alpha,\n"
+                    "  title = {Alpha Title}\n"
+                    "}\n\n"
+                    "@article{beta,\n"
+                    "  title = {Beta Title}\n"
+                    "}\n\n"
+                    "@article{gamma,\n"
+                    "  title = {Gamma Title}\n"
+                    "}\n"
+                )
+
+            expander = LatexExpander(LatexExpandConfig(root_directory=temp_dir))
+            result = expander.flatten_latex(input_file, output_file)
+
+            merged_bib = os.path.join(output_dir, "main_flattened.bib")
+            assert "\\bibliography{main_flattened}" in result
+            assert os.path.exists(merged_bib)
+
+            with open(merged_bib, "r", encoding="utf-8") as f:
+                merged_content = f.read()
+                assert "alpha" in merged_content
+                assert "beta" in merged_content
+                assert "gamma" not in merged_content

--- a/tests/unit/test_expander_core.py
+++ b/tests/unit/test_expander_core.py
@@ -468,14 +468,14 @@ class TestLatexExpanderCore:
                 f.write(
                     "\\documentclass{article}\n"
                     "\\begin{document}\n"
-                    "\\citep{alpha}\n"
+                    "\\citep{beta}\n"
                     "\\input{section}\n"
                     "\\bibliography{refs}\n"
                     "\\end{document}\n"
                 )
 
             with open(included_file, "w", encoding="utf-8") as f:
-                f.write("Nested cite \\cite{beta}.\n")
+                f.write("Nested cite \\cite{alpha}.\n")
 
             with open(bibliography_file, "w", encoding="utf-8") as f:
                 f.write(
@@ -502,6 +502,9 @@ class TestLatexExpanderCore:
                 assert "alpha" in merged_content
                 assert "beta" in merged_content
                 assert "gamma" not in merged_content
+                assert merged_content.index("@article{alpha") < merged_content.index(
+                    "@article{beta"
+                )
 
     def test_normalize_bibliography_output_fixes_pybtex_escaping(self) -> None:
         """Test post-processing for known pybtex escaping issues."""

--- a/tests/unit/test_expander_core.py
+++ b/tests/unit/test_expander_core.py
@@ -58,9 +58,9 @@ class TestLatexExpanderCore:
         )
 
         # Test includegraphics pattern
-        assert (
-            self.expander._includegraphics_pattern.pattern
-            == r"\\(?:includegraphics|plotone|plottwo)(?:\[[^\]]*\])?\{([^}]+)\}(?:\{([^}]+)\})?"
+        assert self.expander._includegraphics_pattern.pattern == (
+            r"\\(?:includegraphics|plotone)(?:\[[^\]]*\])?\{([^}]+)\}"
+            r"|\\plottwo(?:\[[^\]]*\])?\{([^}]+)\}\s*\{([^}]+)\}"
         )
         assert self.expander._bibliography_pattern.pattern == r"\\bibliography\{([^}]+)\}"
         assert (

--- a/tests/unit/test_graphics_unit.py
+++ b/tests/unit/test_graphics_unit.py
@@ -188,6 +188,37 @@ class TestGraphicsUnit:
             assert "\\includegraphics[width=0.5\\textwidth]{figure.pdf}" in result
             mock_copy.assert_called_once()
 
+    def test_process_plottwo_with_whitespace(self) -> None:
+        """Test processing \\plottwo with whitespace between arguments."""
+        with (
+            patch.object(self.expander, "_find_graphics_file") as mock_find,
+            patch.object(self.expander, "_copy_graphics_file") as mock_copy,
+        ):
+            mock_find.side_effect = ["path/to/fig1.pdf", "path/to/fig2.pdf"]
+
+            line = "\\plottwo{fig1} {fig2}"
+            result = self.expander._process_includegraphics(line, ".", "output")
+
+            assert "fig1.pdf" in result
+            assert "fig2.pdf" in result
+            assert mock_copy.call_count == 2
+
+    def test_process_plotone_ignores_following_group(self) -> None:
+        """Test \\plotone only consumes its single argument."""
+        with (
+            patch.object(self.expander, "_find_graphics_file") as mock_find,
+            patch.object(self.expander, "_copy_graphics_file") as mock_copy,
+        ):
+            mock_find.return_value = "path/to/fig.pdf"
+
+            line = "\\plotone{fig} {foo}"
+            result = self.expander._process_includegraphics(line, ".", "output")
+
+            assert "fig.pdf" in result
+            assert "{foo}" in result  # Trailing group left untouched
+            mock_find.assert_called_once_with("fig", ".")
+            mock_copy.assert_called_once()
+
     def test_process_includegraphics_multiple_in_line(self) -> None:
         """Test processing line with multiple includegraphics commands."""
         with (


### PR DESCRIPTION


## Summary

The American Astronomical Society macros provide a simpler alternative to using \includegraphics. This changes the code to support all three graphics commands.

<!-- Describe the purpose of this PR and what it changes -->

## Related Issues

Closes #<!-- issue number -->

## Changes

- [x] Added feature X
- [ ] Fixed bug Y
- [ ] Updated documentation
- [ ] Added tests

## How to Test

<!-- Instructions to verify this PR, commands to run, etc. -->

The AASTeX guide at https://journals.aas.org/aastexguide/ describes the use of

```tex
\plotone{image.jpg}
\plottwo{image1.pdf}{image2.pdf}
```

as simpler alternatives to `\includegraphics`.

I have not added a test for it in the code yet, since I'm not entirely sure you are willing to accept this modification. I have tested it works with my own AAS papers.

## Checklist

- [ ] Code follows the style guidelines
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] CI passes successfully
