### PR TITLE
style: Align pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,25 +17,29 @@ repos:
   hooks:
     - id: isort
       args: ["--profile", "black"]
+      files: ^flatexpy/
 - repo: https://github.com/psf/black
   rev: 25.1.0
   hooks:
   - id: black
     language_version: python3
+    files: ^flatexpy/
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v1.15.0
   hooks:
     - id: mypy
       args: [--ignore-missing-imports, --strict]
-      exclude: ^tests/
+      files: ^flatexpy/
 - repo: https://github.com/PyCQA/flake8
   rev: "7.2.0"
   hooks:
   - id: flake8
-    # max-line-length setting is the same as black
-    args: [--max-line-length, "150", --ignore=E402,--ignore=E800]
-    additional_dependencies: [flake8-bugbear, flake8-builtins, flake8-eradicate, pep8-naming, flake8-expression-complexity, flake8-cognitive-complexity,flake8-docstrings]
-    exclude: ^tests/
+    # max-line-length setting is the same as black.
+    # E203 and W503 are ignored to prevent conflicts with black formatter.
+    # Complexity thresholds are set to a realistic value of 15 for practical CLI development.
+    args: [--max-line-length, "150", --ignore=E402,--ignore=E800,--ignore=E203,--ignore=W503,--max-complexity, "15", --max-expression-complexity=15, --max-cognitive-complexity=15]
+    additional_dependencies: [flake8-bugbear, flake8-builtins, flake8-eradicate, pep8-naming, flake8-expression-complexity, flake8-cognitive-complexity]
+    files: ^flatexpy/
 - repo: https://github.com/pylint-dev/pylint
   rev: v3.3.7
   hooks:
@@ -45,8 +49,9 @@ repos:
       language: python
       types: [python]
       additional_dependencies: [pytest]
-      args: [--max-line-length,"150"]
-      exclude: ^tests/
+      # Disable overly strict pylint checks that are not pragmatic for CLI apps
+      args: [--max-line-length,"150","--init-hook", "import sys; sys.path.insert(0, 'flatexpy')", "--disable=C0415,R0914,R0912,R0915,C0116,C0114"]
+      files: ^flatexpy/
 
 # - repo: https://github.com/markdownlint/markdownlint
 #   rev: v0.13.0


### PR DESCRIPTION
Updates .pre-commit-config.yaml to match the configuration patterns used in ToAmano/cellify. Limits linters and formatters to targets under the flatexpy/ source directory and relaxes/adjusts rules for flake8 and pylint accordingly.