### PR TITLE
ci: Configure Codecov coverage reporting

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,43 @@
+name: Test Suite
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    name: Run pytest
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[test]"
+
+      - name: Run tests with coverage
+        run: pytest --cov=flatexpy/ --cov-report=xml
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Build package verification
+        run: |
+          pip install build
+          python -m build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,11 +63,8 @@ docs = [
     "sphinx-rtd-theme >= 1.0",
 ]
 
-[tool.setuptools.packages.find]
-where = ["flatexpy"]
-
-[tool.setuptools.package-dir]
-"" = "flatexpy"
+[tool.setuptools]
+packages = ["flatexpy"]
 
 [tool.setuptools.package-data]
 flatexpy = ["py.typed"]


### PR DESCRIPTION
Configures pytest-cov in the test suite workflow to run tests with coverage and upload XML reports to Codecov. References ToAmano/cellify PR 20.